### PR TITLE
Rules engine

### DIFF
--- a/something-trivial/src/components/AnswerRow.tsx
+++ b/something-trivial/src/components/AnswerRow.tsx
@@ -3,6 +3,7 @@ import { IQuestion, IAnswer } from '../redux/data/types'
 import { updateAnswer } from '../redux/actions/answerActions';
 import { connect } from 'react-redux';
 import { tallyScore } from '../services/grader';
+import '../pages/RoundPage.css'
 
 interface Props {
   answers: IAnswer[];
@@ -41,14 +42,14 @@ const AnswerRow: React.FC<Props> = (props: Props) => {
 
   return (
     <tr key={name}>
-      <td style={{ fontWeight: "bold" }} >{tallyScore(answers, questions)}</td>
-      <td style={{ fontWeight: "bold" }} >{name}</td>
+      <td className='roundScoreColumn'>{tallyScore(answers, questions)}</td>
+      <td className='roundTeamColumn'>{name}</td>
       {
         questions.map(question => {
           let answer = answers.filter(answer => answer.number === question.number)[0];
           return (answer === undefined) ?
-            <td key={question.id}>-</td> :
-            (<td key={answer.id} style={answerStyle(answer.isCorrect)} onClick={overrideIsCorrectHandler(answer)}> {answer.answer} </td>);
+            <td className='roundAnswerColumn' key={question.id}>-</td> :
+            (<td className='roundAnswerColumn' key={answer.id} style={answerStyle(answer.isCorrect)} onClick={overrideIsCorrectHandler(answer)}> {answer.answer} </td>);
         })
       }
     </tr>

--- a/something-trivial/src/components/FixedTableHeader.tsx
+++ b/something-trivial/src/components/FixedTableHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { IQuestion } from '../redux/data/types'
+
+interface Props {
+  questions: IQuestion[];
+}
+
+const FixedTableHeader: React.FC<Props> = (props: Props) => {
+  const questions = props.questions.sort();
+
+
+  const tableStyle = {
+    position: 'fixed',
+    top: '0px',
+    display: 'none',
+    backgroundColor: 'white'
+  };
+  
+  const tempStyle = {
+    position: 'fixed',
+    top: '0px',
+    display: 'none'
+  };
+
+  return (
+    <thead color='red' style={{position:"sticky", top: '0px', zIndex: 5}}>
+    <tr>
+      <th>Score</th>
+      <th>Team</th>
+      {
+        questions.map(question => (
+          <th key={question.id}> {question.answerContains.join(', ')} </th>
+        ))
+      }
+    </tr>
+  </thead>
+  )
+}
+
+export default FixedTableHeader;

--- a/something-trivial/src/components/NewQuestionForm.tsx
+++ b/something-trivial/src/components/NewQuestionForm.tsx
@@ -14,6 +14,7 @@ import { IState, INewQuestion } from '../redux/data/types';
 import { createQuestion } from '../redux/actions/questionActions';
 import { Redirect } from 'react-router-dom';
 import { HOST_PAGE } from './TrivialController';
+import { nodeBuilder } from '../services/answerRules';
 
 type Props = {
   createQuestion: (question: INewQuestion) => void;
@@ -36,7 +37,7 @@ const NewQuestionForm: React.FC<Props> = (props) => {
     setRoundValue(e.target.value);
   };
 
-  const handleGameIdChange = () => (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleGameIdChange = () => () => {
     setGameIdValue('0');
   };
 
@@ -67,12 +68,13 @@ const NewQuestionForm: React.FC<Props> = (props) => {
     let parsedAnswers: string[] = [];
     answers.forEach(answer => { if (answer.trim().length > 0) parsedAnswers.push(answer.trim()) })
 
-    let question = {
+    let question: INewQuestion = {
       gameId: parseInt(gameId),
       round: parseInt(round),
       number: parseInt(number),
       prompt: prompt,
       answerContains: parsedAnswers,
+      rules: nodeBuilder(parsedAnswers),
       points: points
     }
 

--- a/something-trivial/src/components/QuestionLoader.tsx
+++ b/something-trivial/src/components/QuestionLoader.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import { INewQuestion } from '../redux/data/types'
 import { createQuestion } from '../redux/actions/questionActions';
 import { connect } from 'react-redux';
-import { Form, FormGroup, Row, Col, Label, FormText, Input } from 'reactstrap';
+import { Form, FormGroup, Row, Col, Label, FormText, Input, ButtonToolbar, ButtonGroup, Button } from 'reactstrap';
 import questionsLoader from '../services/questionsLoader';
+import { Link } from 'react-router-dom';
+import { NEW_QUESTION_PAGE } from './TrivialController';
 
 interface Props {
   createQuestion: (question: INewQuestion) => void;
@@ -15,21 +17,31 @@ const QuestionLoader: React.FC<Props> = (props: Props) => {
   const loadQuestionsFile = questionsLoader(createQuestion)
 
   return (
-    <Form>
-      <FormGroup>
-        <Row>
-          <Col>
-            <Label for="csvQuestionsFile">CSV Questions File Loader</Label>
-            <FormText color="muted">
-              Select a CSV file of questions for this game to be loaded.
-            </FormText>
-          </Col>
-          <Col>
-            <Input type="file" name="csvQuestionsFile" id="csvQuestionsFile" accept='.csv' onChange={loadQuestionsFile} />
-          </Col>
-        </Row>
-      </FormGroup>
-    </Form>
+    <React.Fragment>
+      <Row style={{ width: '95vw'}}>
+        <Col sm='3'>
+            <h2> Questions </h2>
+            <p> These are the currently loaded questions. </p>
+        </Col>
+
+        <Col sm='3'>
+          <Form>
+            <FormGroup>
+              <Label for="csvQuestionsFile">CSV Questions File Loader</Label>
+              <Input type="file" name="csvQuestionsFile" id="csvQuestionsFile" accept='.csv' onChange={loadQuestionsFile} />
+            </FormGroup>
+          </Form>
+        </Col>
+
+        <Col sm='3'>
+          <ButtonToolbar>
+            <ButtonGroup>
+            <Link to={NEW_QUESTION_PAGE}><Button color="primary" style={{'width': '180px'}}>Create New Question</Button></Link>
+            </ButtonGroup>
+          </ButtonToolbar>
+        </Col>
+      </Row>
+    </React.Fragment>
   )
 }
 

--- a/something-trivial/src/components/RoundSelector.tsx
+++ b/something-trivial/src/components/RoundSelector.tsx
@@ -13,18 +13,21 @@ const RoundSelector: React.FC<Props> = (props) => {
   const rounds = props.rounds;
 
   return (
-    <Row>
-      {
-        rounds.map(round => (
-          <Col sm='auto' key={round}>
-            <Link to={VIEW_ROUND_PAGE(round.toString())}>
-              <Button>
-                Round {round}
-              </Button>
-            </Link>
-          </Col>))
-      }
-    </Row>
+    <React.Fragment>
+      <Row>
+        {
+          rounds.map(round => (
+            <Col sm='auto' key={round} style={{ paddingBottom: '25px' }}>
+              <Link to={VIEW_ROUND_PAGE(round.toString())}>
+                <Button>
+                  Round {round}
+                </Button>
+              </Link>
+            </Col>))
+        }
+      </Row>
+      <br />
+    </React.Fragment>
   );
 };
 

--- a/something-trivial/src/pages/HostPage.tsx
+++ b/something-trivial/src/pages/HostPage.tsx
@@ -10,17 +10,8 @@ class HostPage extends React.Component {
   render() {
     return (
       <Container>
-        <QuestionLoader/>
         <RoundSelector/>
-        <Row>
-          <Col sm='9'>
-            <h2> Questions </h2>
-            <p> These are the currently loaded questions. </p>
-          </Col>
-          <Col sm='3'>
-            <Link to={NEW_QUESTION_PAGE}><Button color="primary" style={{'width': '180px'}}>Create New Question</Button></Link>
-          </Col>
-        </Row>
+        <QuestionLoader/>
         <Row>
           <QuestionsTable />
         </Row>

--- a/something-trivial/src/pages/RoundPage.css
+++ b/something-trivial/src/pages/RoundPage.css
@@ -1,0 +1,44 @@
+.roundTeamNumberColumn {
+    min-width: 25px;
+    max-width: 25px;
+}
+
+.roundScoreColumn {
+    min-width: 65px;
+    max-width: 65px;
+}
+
+.roundTeamColumn {
+    min-width: 125px;
+    max-width: 125px;
+}
+
+.roundAnswerColumn {
+    min-width: 125px;
+    max-width: 125px;
+}
+
+.roundTable {
+    display: block;
+    width: fit-content;
+    overflow-x: scroll;
+}
+
+.roundTableContainer {
+    display: block;
+    overflow-x: auto;
+    max-width: 95vw;
+}
+
+.roundTableBody {
+    max-height: 70vh;
+    display: block;
+    overflow: visible;
+    display: display-outside;
+    resize: vertical;
+}
+
+.roundTableBodyWrapper {
+    overflow-y: auto;
+    width: 2710px
+}

--- a/something-trivial/src/pages/RoundPage.tsx
+++ b/something-trivial/src/pages/RoundPage.tsx
@@ -7,7 +7,7 @@ import { IQuestion, IState, IAnswer, INewAnswer } from '../redux/data/types';
 import { createAnswer, updateAnswer, removeAnswer } from '../redux/actions/answerActions';
 import AnswerRow from '../components/AnswerRow';
 import answersLoader from '../services/answersLoader';
-import { grade, tallyScore } from '../services/grader';
+import { tallyScore } from '../services/grader';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 type Props = {
@@ -42,8 +42,7 @@ const RoundPage: React.FC<Props> = (props) => {
     
     answers.forEach(answer => {
       let question = questions.filter(question => question.number === answer.number)[0];
-      let answerContains = question.answerContains;
-      answer.isCorrect = grade(answer.answer, answerContains)
+      answer.isCorrect = question.rules.satisfies(answer.answer)
       updateAnswer(answer);
     })
   }
@@ -75,7 +74,7 @@ const RoundPage: React.FC<Props> = (props) => {
   return (
     <React.Fragment>
       <CopyToClipboard text={scoresAsColumn()}><button>Copy to Clipboard</button></CopyToClipboard>
-      <Row float>
+      <Row>
         <Col></Col><Button color='primary' onClick={gradeAnswersHandler}>[✓] Grade Answers</Button><Col/>
         <Col></Col><Button color='danger' onClick={removeAnswersHandler}>[X] Clear Answers</Button><Col/>
       </Row>

--- a/something-trivial/src/redux/data/classes.tsx
+++ b/something-trivial/src/redux/data/classes.tsx
@@ -1,6 +1,12 @@
-import { IQuestion, INewQuestion, IAnswer, INewAnswer } from "./types";
+import { 
+  IQuestion,
+  INewQuestion,
+  IAnswer,
+  INewAnswer,
+  IAnswerRuleNode
+} from "./types";
 
-export class Question implements IQuestion{
+export class Question implements IQuestion {
   constructor(question: INewQuestion, id: number) {
     this.gameId = question.gameId;
     this.round = question.round;
@@ -8,6 +14,7 @@ export class Question implements IQuestion{
     this.prompt = question.prompt;
     this.answerContains = question.answerContains;
     this.points = question.points;
+    this.rules = question.rules;
     this.id = id;
   }
 
@@ -17,10 +24,11 @@ export class Question implements IQuestion{
   number: number;
   prompt: string;
   points: number;
+  rules: IAnswerRuleNode;
   answerContains: string[];
 }
 
-export class Answer implements IAnswer{
+export class Answer implements IAnswer {
   constructor(answer: INewAnswer, id: number) {
     this.gameId = answer.gameId;
     this.id = id;

--- a/something-trivial/src/redux/data/questions.ts
+++ b/something-trivial/src/redux/data/questions.ts
@@ -1,3 +1,5 @@
+import { ContainsValueNode, AndNode } from "../../services/answerRules";
+
 export default [
     {
         gameId: 0,
@@ -6,6 +8,7 @@ export default [
         number: 1,
         prompt: `What is the Latin word for dragon?`,
         answerContains: [`Draco`],
+        rules: new ContainsValueNode(`Draco`),
         points: 1
     },
     {
@@ -15,6 +18,7 @@ export default [
         number: 2,
         prompt: ` This is an atmospheric subgenre of alternative rock that relies on sonic textures as much as melody. It often features breathy vocals and processed, echo-laden guitars and synthesizers.`,
         answerContains: [`Dream`, `Pop`],
+        rules: new AndNode(new ContainsValueNode(`Dream`), new ContainsValueNode(`Pop`)),
         points: 1
     },
     {
@@ -24,6 +28,7 @@ export default [
         number: 3,
         prompt: `What was the middle name of US President Franklin Roosevelt?`,
         answerContains: [`Delano`],
+        rules: new ContainsValueNode(`Delano`),
         points: 1
     },
     {
@@ -33,6 +38,7 @@ export default [
         number: 4,
         prompt: `This psychological theory says that When we predict how long we will feel about some event, we tend to over-estimate the longevity of the emotional impact.`,
         answerContains: [`Durability`, `Bias`],
+        rules: new AndNode(new ContainsValueNode(`Durability`), new ContainsValueNode(`Bias`)),
         points: 1
     },
     {
@@ -42,6 +48,7 @@ export default [
         number: 5,
         prompt: `Published in 1897, what famous horror novel was written by Bram Stoker?`,
         answerContains: [`Dracula`],
+        rules: new ContainsValueNode(`Dracula`),
         points: 1
     },
     {
@@ -51,6 +58,7 @@ export default [
         number: 6,
         prompt: `This hindi word which means Happy Heart and is the name of a famous South Indian Bread with a Sweet filling in it.`,
         answerContains: [`Dilkush`],
+        rules: new ContainsValueNode(`Dilkush`),
         points: 1
     },
     {
@@ -60,6 +68,7 @@ export default [
         number: 7,
         prompt: `Who plays Jess Day in TV series "New Girl"?`,
         answerContains: [`Zooey`, `Deschanel`],
+        rules: new AndNode(new ContainsValueNode(`Zooey`), new ContainsValueNode(`Deschanel`)),
         points: 1
     },
     {
@@ -69,6 +78,7 @@ export default [
         number: 8,
         prompt: `This river flows from Lake St. Clair west and south to Lake Erie as a strait in the Great Lakes system.`,
         answerContains: [`Detroit`],
+        rules: new ContainsValueNode(`Detroit`),
         points: 1
     },
     {
@@ -78,6 +88,7 @@ export default [
         number: 9,
         prompt: `Born in 1996, what name was given to the world's first cloned sheep?`,
         answerContains: [`Dolly`],
+        rules: new ContainsValueNode(`Dolly`),
         points: 1
     },
     {
@@ -87,6 +98,7 @@ export default [
         number: 10,
         prompt: `This Irish singer-songwriter and musician is best known for their 2019 single "Outnumbered".`,
         answerContains: [`Dermot`, `Kennedy`],
+        rules: new AndNode(new ContainsValueNode(`Dermot`), new ContainsValueNode(`Kennedy`)),
         points: 1
     },
 ]

--- a/something-trivial/src/redux/data/types.tsx
+++ b/something-trivial/src/redux/data/types.tsx
@@ -8,12 +8,52 @@ interface INewQuestion {
   readonly number: number;
   readonly prompt: string;
   readonly answerContains: Array<string>;
+  readonly rules: IAnswerRuleNode;
   readonly points: number;
 }
 
-interface IAnswer extends INewAnswer{
+/**
+ * Defines interface for a Answer Rule Node.
+ * 
+ * Answer rules are defined by a tree of Answer Rule Nodes. By traversing the tree,
+ * you can determine if the submitted answer is correct or incorrect.
+ */
+interface IAnswerRuleNode {
+  satisfies: (answer: string) => boolean;
+  remainingAnswer: string;
+}
+
+/**
+ * Defines interface for a Answer Rule Node.
+ * 
+ * Answer rules are defined by a tree of Answer Rule Nodes. By traversing the tree,
+ * you can determine if the submitted answer is correct or incorrect.
+ */
+interface IOrchestratorNode extends IAnswerRuleNode {
+  left: IAnswerRuleNode,
+  right: IAnswerRuleNode
+}
+
+/**
+ * Defines interface for a Answer Rule Node.
+ * 
+ * Answer rules are defined by a tree of Answer Rule Nodes. By traversing the tree,
+ * you can determine if the submitted answer is correct or incorrect.
+ */
+interface IInvokerNode extends IAnswerRuleNode {
+  readonly parameter: any
+}
+
+/**
+ * isCorrect can be in one of 3 states:
+ *  - ungraded (undefined)
+ *  - graded as correct (true)
+ *  - graded as incorrect (false)
+ * We will not differentiate between auto-grading and manual grading for now.
+ */
+interface IAnswer extends INewAnswer {
   readonly id: number;
-  isCorrect: boolean | undefined; // can be in one of 3 states: ungraded (undefined), graded as correct (true), or graded as incorrect (false). We will not differentiate between auto-grading and manual grading for now.
+  isCorrect: boolean | undefined;
 }
 
 interface INewAnswer {
@@ -34,5 +74,8 @@ export type {
   INewQuestion,
   IAnswer,
   INewAnswer,
-  IState
+  IState,
+  IAnswerRuleNode,
+  IOrchestratorNode,
+  IInvokerNode
 }

--- a/something-trivial/src/redux/reducers/anwerReducer.tsx
+++ b/something-trivial/src/redux/reducers/anwerReducer.tsx
@@ -30,11 +30,18 @@ const answerReducer = (answers: IAnswer[], action: Action): IAnswer[] => {
   }
 };
 
-const add = (answers: IAnswer[], newAnswer?: INewAnswer): IAnswer[] => (
-  (newAnswer === undefined) ?
-    (answers) :
-    ([...answers, new Answer(newAnswer, generateId(answers))])
-);
+const add = (answers: IAnswer[], newAnswer?: INewAnswer): IAnswer[] => {
+  if (newAnswer === undefined) {
+    return answers;
+  }
+
+  let id = findAnswer(answers, newAnswer);
+  if (id !== undefined) {
+    return update(answers, new Answer(newAnswer, id));
+  }
+
+  return [...answers, new Answer(newAnswer, generateId(answers))];
+};
 
 const remove = (answers: IAnswer[], id?: number): IAnswer[] => (
   (id === undefined) ?
@@ -60,5 +67,19 @@ const generateId = (answers: IAnswer[], index?: number): number => (
       generateId(remove(answers, answers[0].id),
         (index > answers[0].id) ? (index) : (answers[0].id + 1))))
 );
+
+const findAnswer = (answers: IAnswer[], answer: INewAnswer): number | undefined => {
+  let match = answers.filter(a =>
+    a.gameId === answer.gameId &&
+    a.round === answer.round &&
+    a.number === answer.number &&
+    a.teamName === answer.teamName);
+
+  if (match.length > 0) {
+    return match[0].id
+  }
+
+  return undefined;
+};
 
 export default answerReducer;

--- a/something-trivial/src/redux/reducers/questionReducer.tsx
+++ b/something-trivial/src/redux/reducers/questionReducer.tsx
@@ -30,11 +30,18 @@ const questionReducer = (questions: IQuestion[], action: Action): IQuestion[] =>
   }
 };
 
-const add = (questions: IQuestion[], newQuestion?: INewQuestion): IQuestion[] => (
-  (newQuestion === undefined) ?
-    (questions) :
-    ([...questions, new Question(newQuestion, generateId(questions))])
-);
+const add = (questions: IQuestion[], newQuestion?: INewQuestion): IQuestion[] => {
+  if (newQuestion === undefined) {
+    return questions;
+  }
+
+  let id = findQuestion(questions, newQuestion);
+  if (id !== undefined) {
+    return update(questions, new Question(newQuestion, id));
+  }
+
+  return [...questions, new Question(newQuestion, generateId(questions))];
+};
 
 const remove = (questions: IQuestion[], id?: number): IQuestion[] => (
   (id === undefined) ?
@@ -60,5 +67,18 @@ const generateId = (questions: IQuestion[], index?: number): number => (
       generateId(remove(questions, questions[0].id),
         (index > questions[0].id) ? (index) : (questions[0].id + 1))))
 );
+
+const findQuestion = (questions: IQuestion[], question: INewQuestion): number | undefined => {
+  let match = questions.filter(q =>
+    q.gameId === question.gameId &&
+    q.round === question.round &&
+    q.number === question.number);
+
+  if (match.length > 0) {
+    return match[0].id
+  }
+
+  return undefined;
+};
 
 export default questionReducer;

--- a/something-trivial/src/services/answerRules.ts
+++ b/something-trivial/src/services/answerRules.ts
@@ -1,0 +1,114 @@
+import { IInvokerNode, IAnswerRuleNode, IOrchestratorNode } from "../redux/data/types";
+
+
+/**
+ * TrueNode always returns true.
+ */
+export class TrueNode implements IAnswerRuleNode {
+  satisfies = () => true;
+  remainingAnswer = '';
+}
+
+/**
+ * AndNode defines an AND operation to be composed between the left and right sub-nodes.
+ * 
+ * If both the left and the right node return correct, then this node returns correct. Else, incorrect.
+ */
+export class AndNode implements IOrchestratorNode {
+  constructor(left: IAnswerRuleNode, right: IAnswerRuleNode) {
+    this.satisfies = (answer: string) => {
+      let satisfied = this.left.satisfies(answer);
+      this.remainingAnswer = left.remainingAnswer;
+
+      if (!satisfied) {
+        return satisfied;
+      }
+
+      satisfied = this.right.satisfies(this.remainingAnswer)
+      this.remainingAnswer = right.remainingAnswer;
+      return satisfied;
+    };
+
+    this.left = left;
+    this.right = right;
+  }
+
+  satisfies: (answer: string) => boolean;
+  remainingAnswer = '';
+  left: IAnswerRuleNode;
+  right: IAnswerRuleNode;
+}
+
+/**
+ * OrNode defines an OR operation to be composed between the left and right sub-nodes.
+ * 
+ * If either the left or the right node return correct, then this node returns correct. Else, incorrect.
+ */
+export class OrNode implements IOrchestratorNode {
+  constructor(left: IAnswerRuleNode, right: IAnswerRuleNode) {
+    this.satisfies = (answer: string) => {
+      let satisfied = this.left.satisfies(answer);
+      this.remainingAnswer = left.remainingAnswer;
+
+      if (satisfied) {
+        return satisfied;
+      }
+
+      satisfied = this.right.satisfies(this.remainingAnswer)
+      this.remainingAnswer = right.remainingAnswer;
+      return satisfied;
+    };
+    
+    this.left = left;
+    this.right = right;
+  }
+
+  satisfies: (answer: string) => boolean;
+  remainingAnswer = '';
+  left: IAnswerRuleNode;
+  right: IAnswerRuleNode;
+}
+
+/**
+ * ContainsValueNode returns true if the answer contains the given string parameter. Else false.
+ */
+export class ContainsValueNode implements IInvokerNode {
+  constructor(value: string) {
+    this.satisfies = (answer: string) => {
+      let index = answer.toLowerCase().indexOf(value.toLowerCase());
+
+      if (index < 0) {
+        this.remainingAnswer = '';
+        return false;
+      }
+
+      this.remainingAnswer = (answer.slice(0, index).trim + answer.slice(index + this.parameter.length)).trim();
+      return true;
+    };
+
+    this.remainingAnswer = '';
+    this.parameter = value;
+  }
+
+  satisfies: (answer: string) => boolean;
+  remainingAnswer: string;
+  readonly parameter: string;
+}
+
+export const nodeBuilder = (nodes: string[]): IAnswerRuleNode => {
+  if (nodes.length === 0) {
+    return new TrueNode();
+  }
+  if (nodes.length === 1) {
+    return new ContainsValueNode(nodes[0]);
+  }
+  return new AndNode(new ContainsValueNode(nodes[0]), nodeBuilder(nodes.slice(1)));
+}
+
+export default {
+  nodeBuilder,
+  TrueNode,
+  AndNode,
+  OrNode,
+  ContainsValueNode
+}

--- a/something-trivial/src/services/answersLoader.ts
+++ b/something-trivial/src/services/answersLoader.ts
@@ -9,6 +9,7 @@ import { INewAnswer } from '../redux/data/types';
  */
 const answersLoader = (round: number, createAnswer: (answer: INewAnswer) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
   e.preventDefault();
+
   let files = e.target.files;
   if (files === null || files.length === 0) {
     return;
@@ -57,6 +58,9 @@ const answersLoader = (round: number, createAnswer: (answer: INewAnswer) => void
   });
 
   fileReader.readAsText(file);
+  
+  // reset file input so you can load the same file again if you clear them
+  e.target.value = '';
 };
 
 /**

--- a/something-trivial/src/services/grader.ts
+++ b/something-trivial/src/services/grader.ts
@@ -7,6 +7,9 @@ import { IAnswer, IQuestion } from "../redux/data/types";
  * @param answerContains Answer should contain
  */
 export const grade = (answer: string, answerContains: string[]) => {
+  
+
+
   let isCorrect: boolean = true;
   let answers = answer.split(" ");
 

--- a/something-trivial/src/services/grader.ts
+++ b/something-trivial/src/services/grader.ts
@@ -7,9 +7,6 @@ import { IAnswer, IQuestion } from "../redux/data/types";
  * @param answerContains Answer should contain
  */
 export const grade = (answer: string, answerContains: string[]) => {
-  
-
-
   let isCorrect: boolean = true;
   let answers = answer.split(" ");
 

--- a/something-trivial/src/services/questionsLoader.ts
+++ b/something-trivial/src/services/questionsLoader.ts
@@ -45,7 +45,7 @@ const questionsLoader = (createQuestion: (question: INewQuestion) => void) => (e
       prompt: record[2],
       answerContains: record[3].split(' '),
       rules: nodeBuilder(record[3].split(' ')),
-      points: (record.length > 4 && !isNaN(parseInt(record[4]))) ? parseInt(record[4]) : 1
+      points: (record.length > 4 && !isNaN(parseFloat(record[4]))) ? parseFloat(record[4]) : 1
     }
 
     createQuestion(question);
@@ -68,6 +68,9 @@ const questionsLoader = (createQuestion: (question: INewQuestion) => void) => (e
   });
 
   fileReader.readAsText(file);
+
+  // reset value so you can load the same file again.
+  e.target.value = '';
 };
 
 /**

--- a/something-trivial/src/services/questionsLoader.ts
+++ b/something-trivial/src/services/questionsLoader.ts
@@ -1,5 +1,6 @@
 import parse from 'csv-parse';
 import { INewQuestion } from '../redux/data/types';
+import { nodeBuilder } from './answerRules';
 
 /**
  * Creates answer objects from the CSV file and loads them into Redux store.
@@ -43,6 +44,7 @@ const questionsLoader = (createQuestion: (question: INewQuestion) => void) => (e
       number: parseInt(record[1]),
       prompt: record[2],
       answerContains: record[3].split(' '),
+      rules: nodeBuilder(record[3].split(' ')),
       points: (record.length > 4 && !isNaN(parseInt(record[4]))) ? parseInt(record[4]) : 1
     }
 


### PR DESCRIPTION
Note: this PR effectively finishes version 1.0 of the Trivia App. It has been used for trivia grading twice now and I feel pretty confident in this initial version as being usable.

Bunch of small changes and bug fixes.

- Round page view overhauled so the table header is fixed while the table rows are scrollable.
- CSS broken out to separate file, fixed column widths to ensure data lines up.
- Won't load duplicate questions or answers with same game/round/number, will overwrite old data.
- Can load same CSV without having to navigate to another page first.
- Sorts team names case-insensitive.
- Can clip team names.